### PR TITLE
Improvements to GET multiple rows and PUT endpoints

### DIFF
--- a/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/AdminDataExplorerApiClient.scala
+++ b/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/AdminDataExplorerApiClient.scala
@@ -127,11 +127,8 @@ object AdminDataExplorerApiClient {
 
     override def viewItems(tableName: String, id: List[String]): Future[List[Map[String, String]]] = {
       val path = ServerAPI.path :+ "admin" :+ "tables" :+ tableName
-      val parameters = Map(
-        "filter" -> id.mkString
-      )
-      val uri = ServerAPI.withPath(path).withParams(parameters)
-
+      val primaryKeyParam = Json.toJson(Map("id" -> id)).toString()
+      val uri = ServerAPI.withPath(path).withParams(Map("filter" -> primaryKeyParam))
       prepareRequest[List[Map[String, String]]]
         .get(uri)
         .send(backend)

--- a/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/models/AdminUpdateTable.scala
+++ b/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/models/AdminUpdateTable.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.{Format, Json}
 
 object AdminUpdateTable {
   case class Request(data: Map[String, String])
-  case class Response(noData: String = "")
+  case class Response(id: String)
 
   implicit val adminUpdateTableRequestFormat: Format[Request] =
     Json.format[Request]

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/AppRouter.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/AppRouter.scala
@@ -38,7 +38,8 @@ class AppRouter @Inject() (adminController: AdminController) extends SimpleRoute
 
     // get table resources by ids
     case GET(p"/admin/tables/$tableName" ? q"filter=$fieldStr") =>
-      val filter = fieldStr.toStringMap.values.headOption.map(_.toStringList).getOrElse(List.empty)
+      // fieldStr is a string like: "List(..., ..., ...)" that's why we substring it
+      val filter = fieldStr.substring(6, fieldStr.length - 1).toStringList
       adminController.find(tableName, filter)
 
     // create table resource

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/controllers/AdminController.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/controllers/AdminController.scala
@@ -72,7 +72,7 @@ class AdminController @Inject() (
       _ <- adminUser(request)
       _ = logger.info(s"Update row from $tableName where primaryKey = $primaryKeyValue, body = $body")
       _ <- adminService.update(tableName, primaryKeyValue, body)
-      response = AdminUpdateTable.Response()
+      response = AdminUpdateTable.Response(id = primaryKeyValue)
     } yield Ok(Json.toJson(response))
   }
 

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/models/SortParameter.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/models/SortParameter.scala
@@ -14,8 +14,6 @@ case class SortParameter(field: String, ordering: String) {
 object SortParameter {
   def fromString(str: String): SortParameter = {
     val sort = str.toStringList
-    // val sortField = sort.headOption.filterNot(_ == "id").getOrElse(primaryKeyField)
     SortParameter(field = sort.head, ordering = sort(1))
   }
-
 }

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/package.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/package.scala
@@ -1,8 +1,7 @@
 package net.wiringbits.webapp.utils.admin
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import net.wiringbits.webapp.utils.admin.utils.models.QueryParameters
+import play.api.libs.json.Json
 
 package object utils {
   implicit class StringToDataTypesExt(val str: String) extends AnyVal {
@@ -13,9 +12,8 @@ package object utils {
 
     // convert json object string (for example: "{}") to Map
     implicit def toStringMap: Map[String, String] = {
-      val mapper = new ObjectMapper()
-      mapper.registerModule(DefaultScalaModule)
-      mapper.readValue(str, classOf[Map[String, String]])
+      val maybe = Json.parse(str).validate[Map[String, String]]
+      maybe.getOrElse(Map.empty)
     }
   }
 

--- a/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -88,13 +88,13 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "fail if the table row doesn't exists" in withApiClient { client =>
-      val userIds = List(UUID.randomUUID().toString, UUID.randomUUID().toString)
+      val userIds = List(UUID.randomUUID().toString)
       val error = client.viewItems("users", userIds).expectError
       error must be(s"Cannot find item in users with id ${userIds.headOption.value}")
     }
   }
 
-  "POST /admin/tables/users" should {
+  "POST /admin/tables/:tableName" should {
     "create a new user" in withApiClient { client =>
       val name = "wiringbits"
       val email = "test@wiringbits.net"
@@ -122,7 +122,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
     error must be(s"A field doesn't correspond to this table schema")
   }
 
-  "PUT /admin/tables/users" should {
+  "PUT /admin/tables/:tableName" should {
     "update a new user" in withApiClient { client =>
       val request = AdminCreateTable.Request(
         Map("name" -> "wiringbits", "email" -> "test@wiringbits.net", "password" -> "wiringbits")
@@ -134,10 +134,11 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
       val email = "wiringbits@wiringbits.net"
       val updateRequest = Map("email" -> email)
-      client.updateItem("users", userId, updateRequest).futureValue
+      val updateResponse = client.updateItem("users", userId, updateRequest).futureValue
 
       val newResponse = client.viewItem("users", userId).futureValue
       val emailResponse = newResponse.find(_._1 == "email").value._2
+      updateResponse.id must be(userId)
       emailResponse must be(email)
     }
   }

--- a/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -7,6 +7,8 @@ import net.wiringbits.webapp.utils.admin.controllers.AdminController
 import net.wiringbits.webapp.utils.api.models.AdminCreateTable
 import play.api.inject.guice.GuiceApplicationBuilder
 
+import java.util.UUID
+
 class AdminControllerSpec extends PlayPostgresSpec {
 
   override def guiceApplicationBuilder(container: PostgreSQLContainer): GuiceApplicationBuilder = {
@@ -17,18 +19,78 @@ class AdminControllerSpec extends PlayPostgresSpec {
     appBuilder.router(appRouter)
   }
 
-  "GET /admin/tables/users" should {
+  "GET /admin/tables" should {
+    "return tables from modules" in withApiClient { client =>
+      val response = client.getTables.futureValue
+      val tableName = response.data.map(_.name).headOption.value
+      tableName must be("users")
+    }
+  }
+
+  "GET /admin/tables/:tableName" should {
     "return users table" in withApiClient { client =>
       val response = client.getTableMetadata("users", List("name", "ASC"), List(0, 9), "{}").futureValue
       response.size must be(0)
     }
-  }
 
-  "GET /admin/tables/aaaaaaaaaaa" should {
     "fail when table doesn't exists" in withApiClient { client =>
       val invalidTableName = "aaaaaaaaaaa"
       val error = client.getTableMetadata(invalidTableName, List("name", "ASC"), List(0, 9), "{}").expectError
       error must be(s"Unexpected error because the DB table wasn't found: $invalidTableName")
+    }
+  }
+
+  "GET /admin/tables/:tableName/:primaryKey" should {
+    "return table row" in withApiClient { client =>
+      val tableName = "users"
+      val name = "wiringbits"
+      val email = "test@wiringbits.net"
+      val password = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name, "email" -> email, "password" -> password))
+      client.createItem(tableName, request).futureValue
+
+      val users = client.getTableMetadata(tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+      val userId = users.headOption.value.find(_._1 == "id").value._2
+
+      val response = client.viewItem(tableName, userId).futureValue
+      response.find(_._1 == "name").value._2 must be(name)
+      response.find(_._1 == "email").value._2 must be(email)
+      response.find(_._1 == "password").value._2 must be(password)
+      response.find(_._1 == "id").value._2 must be(userId)
+    }
+
+    "fail if the table row doesn't exists" in withApiClient { client =>
+      val userId = UUID.randomUUID().toString
+      val error = client.viewItem("users", userId).expectError
+      error must be(s"Cannot find item in users with id $userId")
+    }
+  }
+
+  "GET /admin/tables/:tableName/:primaryKeys" should {
+    "return table rows" in withApiClient { client =>
+      val tableName = "users"
+      val numOfCreatedUsers = 3
+      Range.apply(0, numOfCreatedUsers).foreach { i =>
+        val request = AdminCreateTable
+          .Request(Map("name" -> "wiringbits", "email" -> s"test@wiringbits$i.net", "password" -> "wiringbits"))
+        client.createItem(tableName, request).futureValue
+      }
+      val users = client.getTableMetadata(tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+      val userIds = users.map(_.find(_._1 == "id").value._2)
+      val response = client.viewItems(tableName, userIds).futureValue
+      val sameName = response.flatMap(_.find(_._1 == "name")).forall(_._2 == "wiringbits")
+      val samePassword = response.flatMap(_.find(_._1 == "password")).forall(_._2 == "wiringbits")
+
+      response.size must be(userIds.length)
+      response.size must be(numOfCreatedUsers)
+      sameName must be(true)
+      samePassword must be(true)
+    }
+
+    "fail if the table row doesn't exists" in withApiClient { client =>
+      val userIds = List(UUID.randomUUID().toString, UUID.randomUUID().toString)
+      val error = client.viewItems("users", userIds).expectError
+      error must be(s"Cannot find item in users with id ${userIds.headOption.value}")
     }
   }
 
@@ -69,8 +131,6 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
       val response = client.getTableMetadata("users", List("user_id", "ASC"), List(0, 9), "{}").futureValue
       val userId = response.headOption.value.find(_._1 == "id").value._2
-      println(response)
-      println(userId)
 
       val email = "wiringbits@wiringbits.net"
       val updateRequest = Map("email" -> email)


### PR DESCRIPTION
- React-admin throws an error when the update endpoint response doesn't return the ID of the item that was updated
- Endpoint to get multiple rows wasn't working and the CI didn't catch the error because the endpoint didn't had tests (fix error and added tests)
- Remove jackson usage based in comment from #79 