### PR TITLE
Allow to add custom buttons to react-admin

### DIFF
--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/AdminView.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/AdminView.scala
@@ -5,32 +5,31 @@ import japgolly.scalajs.react.vdom.VdomNode
 import net.wiringbits.webapp.utils.api.models.AdminGetTables
 import net.wiringbits.webapp.utils.ui.web.components.{EditGuesser, ListGuesser}
 import net.wiringbits.webapp.utils.ui.web.facades.reactadmin._
+import net.wiringbits.webapp.utils.ui.web.models.TableAction
 import org.scalajs.macrotaskexecutor.MacrotaskExecutor.Implicits.global
 
 import scala.concurrent.Future
 
 object AdminView {
-  private def AdminTables(api: API, response: AdminGetTables.Response) = {
+  private def AdminTables(api: API, response: AdminGetTables.Response, tableActions: List[TableAction]) = {
     val tablesUrl = s"${api.url}/admin/tables"
 
     def buildResources: List[VdomNode] = {
       response.data.map { table =>
+        val actions = tableActions.find(_.tableName == table.name)
         Resource(
           _.name := table.name,
           _.list := ListGuesser(table),
-          _.edit := EditGuesser(table)
+          _.edit := EditGuesser(table, actions)
         )
       }
     }
 
     val resources = buildResources
-    Admin(
-      _.dataProvider :=
-        simpleRestProvider(tablesUrl)
-    )(resources: _*)
+    Admin(_.dataProvider := simpleRestProvider(tablesUrl))(resources: _*)
   }
 
-  def component(api: API): Future[Factory[Admin.Props]] = {
-    api.client.getTables.map { AdminTables(api, _) }
+  def component(api: API, tableActions: List[TableAction] = List.empty): Future[Factory[Admin.Props]] = {
+    api.client.getTables.map { AdminTables(api, _, tableActions) }
   }
 }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/EditGuesser.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/EditGuesser.scala
@@ -1,27 +1,41 @@
 package net.wiringbits.webapp.utils.ui.web.components
 
-import japgolly.scalajs.react.vdom.html_<^.VdomNode
+import japgolly.scalajs.react.vdom.html_<^._
 import net.wiringbits.webapp.utils.api.models.AdminGetTables
 import net.wiringbits.webapp.utils.ui.web.facades.reactadmin._
-import net.wiringbits.webapp.utils.ui.web.models.ColumnType
+import net.wiringbits.webapp.utils.ui.web.models.{ColumnType, TableAction}
 import net.wiringbits.webapp.utils.ui.web.utils.ResponseGuesser
+import org.scalajs.dom
 
 object EditGuesser {
 
-  def apply(response: AdminGetTables.Response.DatabaseTable) = {
+  def apply(response: AdminGetTables.Response.DatabaseTable, tableActionsMaybe: Option[TableAction]) = {
     val fields = ResponseGuesser.getTypesFromResponse(response)
-    val inputs: List[VdomNode] = fields.map { fieldType =>
-      fieldType.`type` match {
-        case ColumnType.Date => DateTimeInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
-        case ColumnType.Text => TextInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
-        case ColumnType.Email => TextInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
-        case ColumnType.Reference(reference, source) =>
-          ReferenceInput(_.source := fieldType.name, _.reference := reference)(
-            SelectInput(_.optionText := source, _.disabled := fieldType.disabled)
-          )
+    val inputs: List[VdomNode] = fields
+      .map { fieldType =>
+        fieldType.`type` match {
+          case ColumnType.Date => DateTimeInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
+          case ColumnType.Text => TextInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
+          case ColumnType.Email => TextInput(_.source := fieldType.name, _.disabled := fieldType.disabled)
+          case ColumnType.Reference(reference, source) =>
+            ReferenceInput(_.source := fieldType.name, _.reference := reference)(
+              SelectInput(_.optionText := source, _.disabled := fieldType.disabled)
+            )
+        }
       }
-    }
-    Edit()(
+
+    val buttons = tableActionsMaybe
+      .map { tableActions =>
+        tableActions.actions.map { action =>
+          val primaryKey = dom.window.location.hash.split("/").lastOption.getOrElse("")
+          Button(_.onClick := (() => action.onClick(primaryKey)))(action.text)
+        }: List[VdomNode]
+      }
+      .getOrElse(List.empty)
+
+    val actions: VdomNode = TopToolbar()(buttons: _*)
+
+    Edit(_.actions := actions)(
       SimpleForm()(inputs: _*)
     )
   }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/ListGuesser.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/ListGuesser.scala
@@ -9,7 +9,7 @@ import net.wiringbits.webapp.utils.ui.web.utils.ResponseGuesser
 
 object ListGuesser {
 
-  def apply(response: AdminGetTables.Response.DatabaseTable): Factory[List.Props] = {
+  def apply(response: AdminGetTables.Response.DatabaseTable): Factory[ComponentList.Props] = {
     val fields = ResponseGuesser.getTypesFromResponse(response)
     val widgetFields: List[VdomNode] = fields.map { field =>
       field.`type` match {
@@ -20,7 +20,7 @@ object ListGuesser {
           ReferenceField(_.reference := reference, _.source := field.name)(TextField(_.source := source))
       }
     }
-    List()(
+    ComponentList()(
       Datagrid(_.rowClick := "edit")(widgetFields: _*)
     )
   }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/facades/reactadmin/ReactAdmin.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/facades/reactadmin/ReactAdmin.scala
@@ -9,6 +9,7 @@ object ReactAdmin extends js.Any {
   def useRecordContext(): js.Dictionary[js.Any] = js.native
 
   val Admin, Create, Datagrid, Edit, EditButton, EmailField, List, ReferenceField, ReferenceInput, Resource,
-      SelectInput, SimpleForm, TextField, DateField, DateTimeInput, TextInput, UrlField, fetchUtils: js.Object =
+      SelectInput, SimpleForm, TextField, DateField, DateTimeInput, TextInput, Button, TopToolbar, UrlField,
+      fetchUtils: js.Object =
     js.native
 }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/facades/reactadmin/components.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/facades/reactadmin/components.scala
@@ -35,6 +35,7 @@ object Edit extends FacadeModule.NodeChildren.Simple {
   override def mkProps = new Props
   class Props extends PropTypes.WithChildren[VdomNode] {
     val children = of[VdomNode]
+    val actions = of[VdomNode]
   }
 }
 
@@ -44,7 +45,24 @@ object EditButton extends FacadeModule.Simple {
   class Props extends PropTypes
 }
 
-object List extends FacadeModule.NodeChildren.Simple {
+object Button extends FacadeModule.NodeChildren.Simple {
+  override def raw = ReactAdmin.Button
+  class Props extends PropTypes.WithChildren[VdomNode] {
+    val children = of[VdomNode]
+    val onClick = of[() => Unit]
+  }
+  override def mkProps = new Props
+}
+
+object TopToolbar extends FacadeModule.NodeChildren.Simple {
+  override def raw = ReactAdmin.TopToolbar
+  class Props extends PropTypes.WithChildren[VdomNode] {
+    val children = of[VdomNode]
+  }
+  override def mkProps = new Props
+}
+
+object ComponentList extends FacadeModule.NodeChildren.Simple {
   override def raw = ReactAdmin.List
   override def mkProps = new Props
   class Props extends PropTypes.WithChildren[VdomNode] {

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/ButtonAction.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/ButtonAction.scala
@@ -1,0 +1,8 @@
+package net.wiringbits.webapp.utils.ui.web.models
+
+/** @param text
+  *   button label that's going to be displayed in react-admin
+  * @param onClick
+  *   this callback has the resource ID of the clicked element
+  */
+case class ButtonAction(text: String, onClick: String => Unit)

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/TableAction.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/TableAction.scala
@@ -1,0 +1,3 @@
+package net.wiringbits.webapp.utils.ui.web.models
+
+case class TableAction(tableName: String, actions: List[ButtonAction])


### PR DESCRIPTION
Now you can add a custom button to run a specific action on any table. For example: `verify a user email` or `resend verification email`. 
This button would look like this in react-admin:
![image](https://user-images.githubusercontent.com/75282728/170626791-9a4545f9-7e4a-44ee-b915-f02e87e4daa6.png)
