### PR TITLE
Propagate 'can records be deleted' config to backend

### DIFF
--- a/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/models/AdminGetTables.scala
+++ b/admin-data-explorer-api/shared/src/main/scala/net/wiringbits/webapp/utils/api/models/AdminGetTables.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.{Format, Json}
 object AdminGetTables {
   case class Response(data: List[Response.DatabaseTable])
   object Response {
-    case class DatabaseTable(name: String, columns: List[TableColumn], primaryKeyName: String)
+    case class DatabaseTable(name: String, columns: List[TableColumn], primaryKeyName: String, canBeDeleted: Boolean)
     case class TableColumn(name: String, `type`: String, editable: Boolean, reference: Option[TableReference])
     case class TableReference(referencedTable: String, referenceField: String)
 

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
@@ -17,5 +17,6 @@ case class TableSettings(
     primaryKeyField: String,
     referenceField: Option[String] = None,
     hiddenColumns: List[String] = List.empty,
-    nonEditableColumns: List[String] = List.empty
+    nonEditableColumns: List[String] = List.empty,
+    canBeDeleted: Boolean = true
 )

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/services/AdminService.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/services/AdminService.scala
@@ -61,7 +61,8 @@ class AdminService @Inject() (
           } yield AdminGetTables.Response.DatabaseTable(
             name = settings.tableName,
             columns = columns,
-            primaryKeyName = settings.primaryKeyField
+            primaryKeyName = settings.primaryKeyField,
+            canBeDeleted = settings.canBeDeleted
           )
         }
       }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/AdminView.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/AdminView.scala
@@ -18,7 +18,7 @@ object AdminView {
       response.data.map { table =>
         Resource(
           _.name := table.name,
-          _.list := ListGuesser(table, dataExplorerSettings),
+          _.list := ListGuesser(table),
           _.edit := EditGuesser(table, dataExplorerSettings)
         )
       }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/EditGuesser.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/EditGuesser.scala
@@ -58,7 +58,7 @@ object EditGuesser {
       }: VdomNode
     }
 
-    val deleteButton: VdomNode = if (dataExplorerSettings.canDelete) DeleteButton() else Fragment()
+    val deleteButton: VdomNode = if (response.canBeDeleted) DeleteButton() else Fragment()
     val toolbar: VdomNode = Toolbar()(
       SaveButton(),
       deleteButton

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/ListGuesser.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/components/ListGuesser.scala
@@ -4,15 +4,12 @@ import io.github.nafg.simplefacade.Factory
 import japgolly.scalajs.react.vdom.html_<^._
 import net.wiringbits.webapp.utils.api.models.AdminGetTables
 import net.wiringbits.webapp.utils.ui.web.facades.reactadmin._
-import net.wiringbits.webapp.utils.ui.web.models.{ColumnType, DataExplorerSettings}
+import net.wiringbits.webapp.utils.ui.web.models.ColumnType
 import net.wiringbits.webapp.utils.ui.web.utils.ResponseGuesser
 
 object ListGuesser {
 
-  def apply(
-      response: AdminGetTables.Response.DatabaseTable,
-      dataExplorerSettings: DataExplorerSettings
-  ): Factory[ComponentList.Props] = {
+  def apply(response: AdminGetTables.Response.DatabaseTable): Factory[ComponentList.Props] = {
     val fields = ResponseGuesser.getTypesFromResponse(response)
 
     val widgetFields: List[VdomNode] = fields.map { field =>
@@ -25,7 +22,7 @@ object ListGuesser {
       }
     }
     ComponentList()(
-      Datagrid(_.rowClick := "edit", _.bulkActionButtons := dataExplorerSettings.canDelete)(widgetFields: _*)
+      Datagrid(_.rowClick := "edit", _.bulkActionButtons := response.canBeDeleted)(widgetFields: _*)
     )
   }
 }

--- a/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/DataExplorerSettings.scala
+++ b/admin-data-explorer-web/src/main/scala/net/wiringbits/webapp/utils/ui/web/models/DataExplorerSettings.scala
@@ -1,3 +1,3 @@
 package net.wiringbits.webapp.utils.ui.web.models
 
-case class DataExplorerSettings(canDelete: Boolean = true, actions: List[TableAction] = List.empty)
+case class DataExplorerSettings(actions: List[TableAction] = List.empty)


### PR DESCRIPTION
- Now 'can records be deleted' config it's being applied per table instead of globally
- This config now comes from backend instead of frontend 