### PR TITLE
Foreign keys query returns fk_column instead of fk_columns

### DIFF
--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/daos/DatabaseTablesDAO.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/daos/DatabaseTablesDAO.scala
@@ -54,7 +54,7 @@ object DatabaseTablesDAO {
     SQL"""
     SELECT kcu.table_name AS foreign_table, 
       rel_tco.table_name AS primary_table, 
-      string_agg(kcu.column_name, ', ') AS fk_columns
+      kcu.column_name AS fk_column
     FROM information_schema.table_constraints tco
     JOIN information_schema.key_column_usage kcu
       ON tco.constraint_schema = kcu.constraint_schema
@@ -67,7 +67,7 @@ object DatabaseTablesDAO {
       AND rco.unique_constraint_name = rel_tco.constraint_name
     WHERE tco.constraint_type = 'FOREIGN KEY'
       AND kcu.table_name = $tableName
-    GROUP BY kcu.table_schema, kcu.table_name, rel_tco.table_name, rel_tco.table_schema
+    GROUP BY kcu.table_schema, kcu.table_name, kcu.column_name, rel_tco.table_name, rel_tco.table_schema
     ORDER BY kcu.table_schema, kcu.table_name
     """.as(foreignKeyParser.*)
   }

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/daos/package.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/daos/package.scala
@@ -38,7 +38,7 @@ package object daos {
     Macro.parser[ForeignKey](
       "foreign_table",
       "primary_table",
-      "fk_columns"
+      "fk_column"
     )
   }
 


### PR DESCRIPTION
If a table had many foreign key references to another table this query used `string_agg` to create a string of multiple foreign keys instead of separating them in different rows. That's why on this specific case react-admin showed a `TextField` instead of `ReferenceField`.

Now if a table has many references to another table, it will detect all the foreign keys and they will be used on react-admin as `ReferenceField`.
Before:
![image](https://user-images.githubusercontent.com/75282728/172023835-7e3bb25e-0922-4896-bea9-03b6b9256f7f.png)
After:
![image](https://user-images.githubusercontent.com/75282728/172023866-b7f3549b-844e-4453-8710-7485d3f7ba52.png)

