### PR TITLE
Use a specific version from dependencies instead of latest one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -297,11 +297,11 @@ lazy val adminDataExplorerWeb = (project in file("admin-data-explorer-web"))
       "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
     ),
     Compile / npmDependencies ++= Seq(
-      "ra-data-simple-rest" -> "^4.0.0",
-      "react" -> "^17.0.0",
-      "react-admin" -> "^4.0.0",
-      "react-dom" -> "^17.0.0",
-      "react-scripts" -> "^5.0.0"
+      "ra-data-simple-rest" -> "4.1.2",
+      "react" -> "17.0.0",
+      "react-admin" -> "4.1.2",
+      "react-dom" -> "17.0.0",
+      "react-scripts" -> "5.0.0"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -297,7 +297,7 @@ lazy val adminDataExplorerWeb = (project in file("admin-data-explorer-web"))
       "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0"
     ),
     Compile / npmDependencies ++= Seq(
-      "ra-data-simple-rest" -> "4.1.2",
+      "ra-data-simple-rest" -> "4.0.0",
       "react" -> "17.0.0",
       "react-admin" -> "4.1.2",
       "react-dom" -> "17.0.0",


### PR DESCRIPTION
It looks like CI tests from projects that used this module were failing because `react-admin` updated to [4.1.3](https://github.com/marmelab/react-admin/releases/tag/v4.1.3) and we were using the latest version from react-admin, not a specific one 