### PR TITLE
Allow integer primary key in Admin data explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 .bsp/
 .vscode/
 .metals/**
+*.iml
 logs/
 admin/build/
 web/build/

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
@@ -1,6 +1,5 @@
 package net.wiringbits.webapp.utils.admin.config
 
-
 /** @param tableName
   *   name of table in database
   * @param primaryKeyField
@@ -14,7 +13,7 @@ package net.wiringbits.webapp.utils.admin.config
   * @param canBeDeleted
   *   indicates if resources from this table can be deleted
   * @param primaryKeyDataType
-  *   "UUID", or "Int" for SERIAL and BIGSERIAL primary keys
+  *   UUID, Serial, or BigSerial primary keys
   */
 
 case class TableSettings(
@@ -24,5 +23,12 @@ case class TableSettings(
     hiddenColumns: List[String] = List.empty,
     nonEditableColumns: List[String] = List.empty,
     canBeDeleted: Boolean = true,
-    primaryKeyDataType: String = "UUID"
+    primaryKeyDataType: PrimaryKeyDataType = PrimaryKeyDataType.UUID
 )
+
+sealed trait PrimaryKeyDataType extends Product with Serializable
+object PrimaryKeyDataType {
+  final case object UUID extends PrimaryKeyDataType
+  final case object Serial extends PrimaryKeyDataType
+  final case object BigSerial extends PrimaryKeyDataType
+}

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/config/TableSettings.scala
@@ -1,5 +1,6 @@
 package net.wiringbits.webapp.utils.admin.config
 
+
 /** @param tableName
   *   name of table in database
   * @param primaryKeyField
@@ -12,6 +13,8 @@ package net.wiringbits.webapp.utils.admin.config
   *   columns that aren't editable (disabled) via react-admin
   * @param canBeDeleted
   *   indicates if resources from this table can be deleted
+  * @param primaryKeyDataType
+  *   "UUID", or "Int" for SERIAL and BIGSERIAL primary keys
   */
 
 case class TableSettings(
@@ -20,5 +23,6 @@ case class TableSettings(
     referenceField: Option[String] = None,
     hiddenColumns: List[String] = List.empty,
     nonEditableColumns: List[String] = List.empty,
-    canBeDeleted: Boolean = true
+    canBeDeleted: Boolean = true,
+    primaryKeyDataType: String = "UUID"
 )

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/DatabaseTablesRepository.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/repositories/DatabaseTablesRepository.scala
@@ -63,7 +63,12 @@ class DatabaseTablesRepository @Inject() (database: Database)(implicit
     database.withTransaction { implicit conn =>
       val settings = tableSettings.unsafeFindByName(tableName)
       val primaryKeyType = settings.primaryKeyDataType
-      val maybe = DatabaseTablesDAO.find(tableName, settings.primaryKeyField, primaryKeyValue, primaryKeyType)
+      val maybe = DatabaseTablesDAO.find(
+        tableName = tableName,
+        primaryKeyField = settings.primaryKeyField,
+        primaryKeyValue = primaryKeyValue,
+        primaryKeyType = primaryKeyType
+      )
       val columns = DatabaseTablesDAO.getTableColumns(tableName)
       val columnNames = getColumnNames(columns, settings.primaryKeyField)
       maybe.map(x => TableData(x.convertToMap(columnNames)))
@@ -74,7 +79,12 @@ class DatabaseTablesRepository @Inject() (database: Database)(implicit
     database.withConnection { implicit conn =>
       val primaryKeyField = tableSettings.unsafeFindByName(tableName).primaryKeyField
       val primaryKeyType = tableSettings.unsafeFindByName(tableName).primaryKeyDataType
-      DatabaseTablesDAO.create(tableName, body, primaryKeyField, primaryKeyType)
+      DatabaseTablesDAO.create(
+        tableName = tableName,
+        body = body,
+        primaryKeyField = primaryKeyField,
+        primaryKeyType = primaryKeyType
+      )
     }
   }
 
@@ -95,7 +105,13 @@ class DatabaseTablesRepository @Inject() (database: Database)(implicit
           (field, value)
         }
         val primaryKeyType = settings.primaryKeyDataType
-        DatabaseTablesDAO.update(tableName, fieldsAndValues, settings.primaryKeyField, primaryKeyValue, primaryKeyType)
+        DatabaseTablesDAO.update(
+          tableName = tableName,
+          fieldsAndValues = fieldsAndValues,
+          primaryKeyField = settings.primaryKeyField,
+          primaryKeyValue = primaryKeyValue,
+          primaryKeyType = primaryKeyType
+        )
       }
     }
 
@@ -104,7 +120,12 @@ class DatabaseTablesRepository @Inject() (database: Database)(implicit
       database.withConnection { implicit conn =>
         val primaryKeyField = tableSettings.unsafeFindByName(tableName).primaryKeyField
         val primaryKeyType = tableSettings.unsafeFindByName(tableName).primaryKeyDataType
-        DatabaseTablesDAO.delete(tableName, primaryKeyField, primaryKeyValue, primaryKeyType)
+        DatabaseTablesDAO.delete(
+          tableName = tableName,
+          primaryKeyField = primaryKeyField,
+          primaryKeyValue = primaryKeyValue,
+          primaryKeyType = primaryKeyType
+        )
       }
     }
 

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/QueryBuilder.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/QueryBuilder.scala
@@ -1,15 +1,22 @@
 package net.wiringbits.webapp.utils.admin.utils
 
+import net.wiringbits.webapp.utils.admin.config.PrimaryKeyDataType
 import net.wiringbits.webapp.utils.admin.repositories.models.TableColumn
 
 import scala.collection.mutable
 
 object QueryBuilder {
-  def create(tableName: String, body: Map[String, String], primaryKeyField: String, primaryKeyType: String = "UUID"): String = {
+  def create(
+      tableName: String,
+      body: Map[String, String],
+      primaryKeyField: String,
+      primaryKeyType: PrimaryKeyDataType = PrimaryKeyDataType.UUID
+  ): String = {
     val sqlFields = new mutable.StringBuilder(primaryKeyField)
     val sqlValues = primaryKeyType match {
-      case "UUID" => new mutable.StringBuilder("?")
-      case _ => new mutable.StringBuilder("DEFAULT")
+      case PrimaryKeyDataType.UUID => new mutable.StringBuilder("?")
+      case PrimaryKeyDataType.Serial => new mutable.StringBuilder("DEFAULT")
+      case PrimaryKeyDataType.BigSerial => new mutable.StringBuilder("DEFAULT")
     }
     for ((key, _) <- body) {
       sqlFields.append(s", $key")

--- a/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/QueryBuilder.scala
+++ b/admin-data-explorer-play-server/src/main/scala/net/wiringbits/webapp/utils/admin/utils/QueryBuilder.scala
@@ -5,9 +5,12 @@ import net.wiringbits.webapp.utils.admin.repositories.models.TableColumn
 import scala.collection.mutable
 
 object QueryBuilder {
-  def create(tableName: String, body: Map[String, String], primaryKeyField: String): String = {
+  def create(tableName: String, body: Map[String, String], primaryKeyField: String, primaryKeyType: String = "UUID"): String = {
     val sqlFields = new mutable.StringBuilder(primaryKeyField)
-    val sqlValues = new mutable.StringBuilder("?")
+    val sqlValues = primaryKeyType match {
+      case "UUID" => new mutable.StringBuilder("?")
+      case _ => new mutable.StringBuilder("DEFAULT")
+    }
     for ((key, _) <- body) {
       sqlFields.append(s", $key")
       sqlValues.append(s", ?")

--- a/admin-data-explorer-play-server/src/test/resources/evolutions/default/2.sql
+++ b/admin-data-explorer-play-server/src/test/resources/evolutions/default/2.sql
@@ -1,0 +1,17 @@
+
+-- !Ups
+
+CREATE TABLE uuid_table (
+    id UUID NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE serial_table (
+    id SERIAL NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE big_serial_table (
+    id BIGSERIAL NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);

--- a/admin-data-explorer-play-server/src/test/resources/evolutions/default/2.sql
+++ b/admin-data-explorer-play-server/src/test/resources/evolutions/default/2.sql
@@ -15,3 +15,21 @@ CREATE TABLE big_serial_table (
     id BIGSERIAL NOT NULL PRIMARY KEY,
     name TEXT NOT NULL
 );
+
+-- start at max value. first insert will be at max, second should fail.
+-- ERROR: integer out of range
+CREATE SEQUENCE serial_table_overflow_seq START 2147483647;
+CREATE TABLE serial_table_overflow (
+    id integer NOT NULL DEFAULT nextval('serial_table_overflow_seq') PRIMARY KEY,
+    name TEXT NOT NULL
+);
+ALTER SEQUENCE serial_table_overflow_seq OWNED BY serial_table_overflow.id;
+
+-- start at max value. first insert will be at max, second should fail.
+-- ERROR: nextval: reached maximum value of sequence "big_serial_table_overflow_seq" (9223372036854775807)
+CREATE SEQUENCE big_serial_table_overflow_seq START 9223372036854775807;
+CREATE TABLE big_serial_table_overflow (
+    id bigint NOT NULL DEFAULT nextval('big_serial_table_overflow_seq') PRIMARY KEY,
+    name TEXT NOT NULL
+);
+ALTER SEQUENCE big_serial_table_overflow_seq OWNED BY big_serial_table_overflow.id;

--- a/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -20,9 +20,11 @@ class AdminControllerSpec extends PlayPostgresSpec {
   def uuidSettings: TableSettings = dataExplorerSettings.tables(1)
   def serialSettings: TableSettings = dataExplorerSettings.tables(2)
   def bigSerialSettings: TableSettings = dataExplorerSettings.tables(3)
+  def serialOverflowSettings: TableSettings = dataExplorerSettings.tables(4)
+  def bigSerialOverflowSettings: TableSettings = dataExplorerSettings.tables(5)
 
   def isValidUUID(str: String): Boolean = {
-    if(str == null) return false
+    if (str == null) return false
     Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$").matcher(str).matches()
   }
 
@@ -56,7 +58,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
       val head2 = response.data(1)
       head2.primaryKeyName must be(uuidSettings.primaryKeyField)
-      uuidSettings.referenceField must be (None)
+      uuidSettings.referenceField must be(None)
       uuidSettings.hiddenColumns must be(List.empty)
       uuidSettings.nonEditableColumns must be(List.empty)
 
@@ -67,10 +69,10 @@ class AdminControllerSpec extends PlayPostgresSpec {
       serialSettings.nonEditableColumns must be(List.empty)
 
       val head4 = response.data(3)
-      head4.primaryKeyName must be(serialSettings.primaryKeyField)
-      serialSettings.referenceField must be(None)
-      serialSettings.hiddenColumns must be(List.empty)
-      serialSettings.nonEditableColumns must be(List.empty)
+      head4.primaryKeyName must be(bigSerialSettings.primaryKeyField)
+      bigSerialSettings.referenceField must be(None)
+      bigSerialSettings.hiddenColumns must be(List.empty)
+      bigSerialSettings.nonEditableColumns must be(List.empty)
     }
   }
 
@@ -95,7 +97,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
     "return data from uuid table" in withApiClient { client =>
       val name = "wiringbits"
-      //val uuid_id =  UUID.randomUUID().toString
+      // val uuid_id =  UUID.randomUUID().toString
       val request = AdminCreateTable.Request(
         Map("name" -> name)
       )
@@ -116,7 +118,8 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val request = AdminCreateTable.Request(Map("name" -> name))
       client.createItem(serialSettings.tableName, request).futureValue
 
-      val response = client.getTableMetadata(serialSettings.tableName, List("name", "ASC"), List(0,9), "{}").futureValue
+      val response =
+        client.getTableMetadata(serialSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       val head = response.headOption.value
       // TODO: Find a better way to do this
       val intValue = head.find(_._1 == "id").value._2
@@ -130,7 +133,8 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val request = AdminCreateTable.Request(Map("name" -> name))
       client.createItem(bigSerialSettings.tableName, request).futureValue
 
-      val response = client.getTableMetadata(bigSerialSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+      val response =
+        client.getTableMetadata(bigSerialSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       val head = response.headOption.value
       // TODO: Find a better way to do this
       val intValue = head.find(_._1 == "id").value._2
@@ -139,19 +143,19 @@ class AdminControllerSpec extends PlayPostgresSpec {
       intValue must be("1")
       name must be(nameValue)
     }
-
-
+    
     "return a empty map if there isn't any user" in withApiClient { client =>
       val response = client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       response.size must be(0)
     }
-    
+
     "return an empty map if tables are empty" in withApiClient { client =>
-      val response = client.getTableMetadata(uuidSettings.tableName, List("id", "ASC"), List(0,9), "{}").futureValue
+      val response = client.getTableMetadata(uuidSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
       response.size must be(0)
       val response2 = client.getTableMetadata(serialSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
       response2.size must be(0)
-      val response3 = client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
+      val response3 =
+        client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
       response3.size must be(0)
     }
 
@@ -167,18 +171,21 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
     "return an empty map for range of zero length" in withApiClient { client =>
       val name = "wiringbits"
-      val request = AdminCreateTable.Request(Map("name" -> name)) // can use this for all 3 of the simple tables UUID, SERIAL, BIGSERIAL
+      val request = AdminCreateTable.Request(
+        Map("name" -> name)
+      ) // can use this for all 3 of the simple tables UUID, SERIAL, BIGSERIAL
 
       client.createItem(uuidSettings.tableName, request).futureValue // 1
-      val response1 = client.getTableMetadata(uuidSettings.tableName, List("id","ASC"), List(0,0), "{}").futureValue
-      response1.size must be (0)
+      val response1 = client.getTableMetadata(uuidSettings.tableName, List("id", "ASC"), List(0, 0), "{}").futureValue
+      response1.size must be(0)
 
       client.createItem(serialSettings.tableName, request).futureValue // 2
-      val response2 = client.getTableMetadata(serialSettings.tableName, List("id","ASC"), List(0,0), "{}").futureValue
-      response2.size must be (0)
+      val response2 = client.getTableMetadata(serialSettings.tableName, List("id", "ASC"), List(0, 0), "{}").futureValue
+      response2.size must be(0)
 
       client.createItem(bigSerialSettings.tableName, request).futureValue // 2
-      val response3 = client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 0), "{}").futureValue
+      val response3 =
+        client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 0), "{}").futureValue
       response3.size must be(0)
 
     }
@@ -201,20 +208,22 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val end = 2
       val start = 1
       val returnedElements = end - start
-      //val data = Map() // data for these tables is always nothing. BIG/SERIAL autogenerated.
+      // val data = Map() // data for these tables is always nothing. BIG/SERIAL autogenerated.
       val name = "wiringbits"
 
       val tables = List(uuidSettings, serialSettings, bigSerialSettings)
       // this could just be a for loop instead of for comprehension
-      for(table <- tables)
+      for (table <- tables)
         yield {
           Range.apply(0, 4).foreach { _ =>
-            val request = AdminCreateTable.Request(Map("name" -> name)) // tried using data and got error. I thought val data was in scope but perhaps not
+            val request = AdminCreateTable.Request(
+              Map("name" -> name)
+            ) // tried using data and got error. I thought val data was in scope but perhaps not
             client.createItem(table.tableName, request).futureValue
           }
         }
 
-      for(table <- tables)
+      for (table <- tables)
         yield {
           val response = client.getTableMetadata(table.tableName, List("id", "ASC"), List(start, end), "{}").futureValue
           response.size must be(returnedElements)
@@ -248,15 +257,15 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val expectedName = name + "0"
 
       // insert rows
-      for( table <- tables)
+      for (table <- tables)
         yield {
           Range.apply(0, createdRows).foreach { i =>
             val request = AdminCreateTable.Request(Map("name" -> s"$name$i"))
             client.createItem(table.tableName, request).futureValue
+          }
         }
-      }
 
-      for( table <- tables)
+      for (table <- tables)
         yield {
           val response =
             client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, createdRows), "{}").futureValue
@@ -340,9 +349,9 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
     "return filtered elements for all tables" in withApiClient { client =>
       val createdRows = 4
-      val tables = List(serialSettings,bigSerialSettings)
+      val tables = List(serialSettings, bigSerialSettings)
 
-      for( table <- tables) {
+      for (table <- tables) {
         Range.apply(0, createdRows).foreach { i =>
           val data = Map("name" -> s"wiringbits$i")
           val request = AdminCreateTable.Request(data)
@@ -351,7 +360,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
       }
       val expectedName = "wiringbits0"
 
-      for( table <- tables) {
+      for (table <- tables) {
         val response =
           client
             .getTableMetadata(
@@ -376,8 +385,6 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
   }
 
-
-
   "GET /admin/tables/:tableName/:primaryKey" should {
     "return table row" in withApiClient { client =>
       val name = "wiringbits"
@@ -401,7 +408,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val name = "wiringbits"
       val request = AdminCreateTable.Request(Map("name" -> name))
 
-      for(table <- tables) {
+      for (table <- tables) {
         client.createItem(table.tableName, request).futureValue
 
         val rows = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
@@ -420,10 +427,10 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "fail if the table row doesn't exists for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
+      val tables = List(serialSettings, bigSerialSettings)
       val rand = new Random()
       val id = rand.nextInt(1000) + 100
-      for( table <- tables) {
+      for (table <- tables) {
         val tableName = table.tableName
         val error = client.viewItem(table.tableName, id.toString).expectError
         error must be(s"Cannot find item in $tableName with id $id")
@@ -453,9 +460,9 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "return table rows for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
+      val tables = List(serialSettings, bigSerialSettings)
       val numOfCreatedRows = 3
-      for(table <- tables) {
+      for (table <- tables) {
         Range.apply(0, numOfCreatedRows).foreach { i =>
           val request = AdminCreateTable
             .Request(Map("name" -> s"wiringbits$i"))
@@ -484,7 +491,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val tables = List(serialSettings, bigSerialSettings)
       val rand = new Random()
       val ids = List((rand.nextInt(1000) + 100).toString)
-      for(table <- tables) {
+      for (table <- tables) {
         val tableName = table.tableName
         val error = client.viewItems(tableName, ids).expectError
         error must be(s"Cannot find item in $tableName with id ${ids.headOption.value}")
@@ -503,10 +510,10 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "create a new row for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
+      val tables = List(serialSettings, bigSerialSettings)
       val name = "wiringbits"
 
-      for(table <- tables) {
+      for (table <- tables) {
         val request = AdminCreateTable.Request(Map("name" -> name))
         val response = client.createItem(table.tableName, request).futureValue
         response.noData must be(empty)
@@ -522,13 +529,36 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "fail when a mandatory field is not sent for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
-      //val name = "wiringbits"
-      for(table <- tables) {
+      val tables = List(serialSettings, bigSerialSettings)
+      // val name = "wiringbits"
+      for (table <- tables) {
         val request = AdminCreateTable.Request(Map())
         val error = client.createItem(table.tableName, request).expectError
         error must be(s"There are missing fields: name")
       }
+    }
+
+    "fail when overlow max int value" in withApiClient { client =>
+      val name = "wiringbits"
+      val table = serialOverflowSettings
+      val request = AdminCreateTable.Request(Map("name" -> name))
+      val ignore = client.createItem(table.tableName, request).futureValue
+      ignore.noData must be(empty)
+      val request2 = AdminCreateTable.Request(Map("name" -> s"asdf"))
+      val error = client.createItem(table.tableName, request2).expectError
+      error must be(s"ERROR: integer out of range")
+    }
+    "fail when overlow max bigint value" in withApiClient { client =>
+      val name = "wiringbits"
+      val table = bigSerialOverflowSettings
+      val request = AdminCreateTable.Request(Map("name" -> name))
+      val ignore = client.createItem(table.tableName, request).futureValue
+      ignore.noData must be(empty)
+      val request2 = AdminCreateTable.Request(Map("name" -> s"asdf"))
+      val error = client.createItem(table.tableName, request2).expectError
+      error must be(
+        s"ERROR: nextval: reached maximum value of sequence \"big_serial_table_overflow_seq\" (9223372036854775807)"
+      )
     }
   }
 
@@ -541,10 +571,10 @@ class AdminControllerSpec extends PlayPostgresSpec {
     error must be(s"A field doesn't correspond to this table schema")
   }
   "fail when field in request doesn't exists for all tables" in withApiClient { client =>
-    val tables = List(serialSettings,bigSerialSettings)
+    val tables = List(serialSettings, bigSerialSettings)
     val name = "wiringbits"
     val nonExistentField = "nonExistentField"
-    for(table <- tables) {
+    for (table <- tables) {
       val request = AdminCreateTable.Request(Map("name" -> name, "nonExistentField" -> nonExistentField))
 
       val error = client.createItem(table.tableName, request).expectError
@@ -573,8 +603,8 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "update a new row for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
-      for(table <- tables) {
+      val tables = List(serialSettings, bigSerialSettings)
+      for (table <- tables) {
         val request = AdminCreateTable.Request(
           Map("name" -> "wiringbits")
         )
@@ -609,8 +639,8 @@ class AdminControllerSpec extends PlayPostgresSpec {
     }
 
     "fail if the field in body doesn't exists for all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
-      for(table <- tables) {
+      val tables = List(serialSettings, bigSerialSettings)
+      for (table <- tables) {
         val request = AdminCreateTable.Request(
           Map("name" -> "test")
         )
@@ -647,11 +677,11 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
   "DELETE /admin/tables/:tableName" should {
     "delete a new row in all tables" in withApiClient { client =>
-      val tables = List(serialSettings,bigSerialSettings)
+      val tables = List(serialSettings, bigSerialSettings)
       val name = "wiringbits"
       val request = AdminCreateTable.Request(Map("name" -> name))
 
-      for(table <- tables) {
+      for (table <- tables) {
         client.createItem(table.tableName, request).futureValue
 
         val response = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue

--- a/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -10,10 +10,21 @@ import org.apache.commons.lang3.StringUtils
 import play.api.inject.guice.GuiceApplicationBuilder
 
 import java.util.UUID
+import java.util.regex.Pattern
+import scala.util.Random
 
 class AdminControllerSpec extends PlayPostgresSpec {
   def dataExplorerSettings: DataExplorerSettings = app.injector.instanceOf(classOf[DataExplorerSettings])
   def usersSettings: TableSettings = dataExplorerSettings.tables.headOption.value
+  // TODO: loop through dataExplorerSettings for each table instead of defining usersSettings, uuidSettings
+  def uuidSettings: TableSettings = dataExplorerSettings.tables(1)
+  def serialSettings: TableSettings = dataExplorerSettings.tables(2)
+  def bigSerialSettings: TableSettings = dataExplorerSettings.tables(3)
+
+  def isValidUUID(str: String): Boolean = {
+    if(str == null) return false
+    Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$").matcher(str).matches()
+  }
 
   override def guiceApplicationBuilder(container: PostgreSQLContainer): GuiceApplicationBuilder = {
     val appBuilder = super.guiceApplicationBuilder(container)
@@ -25,8 +36,14 @@ class AdminControllerSpec extends PlayPostgresSpec {
   "GET /admin/tables" should {
     "return tables from modules" in withApiClient { client =>
       val response = client.getTables.futureValue
-      val tableName = response.data.map(_.name).headOption.value
+      val tableName = response.data.map(_.name).headOption.value // users
       tableName must be(usersSettings.tableName)
+      val uuidTable = response.data.map(_.name)(1) // table 2
+      uuidTable must be(uuidSettings.tableName)
+      val serialTable = response.data.map(_.name)(2) // table 3
+      serialTable must be(serialSettings.tableName)
+      val bigSerialTable = response.data.map(_.name)(3) // table 4
+      bigSerialTable must be(bigSerialSettings.tableName)
     }
 
     "return extra config from module" in withApiClient { client =>
@@ -36,6 +53,24 @@ class AdminControllerSpec extends PlayPostgresSpec {
       usersSettings.referenceField must be(None)
       usersSettings.hiddenColumns must be(List.empty)
       usersSettings.nonEditableColumns must be(List.empty)
+
+      val head2 = response.data(1)
+      head2.primaryKeyName must be(uuidSettings.primaryKeyField)
+      uuidSettings.referenceField must be (None)
+      uuidSettings.hiddenColumns must be(List.empty)
+      uuidSettings.nonEditableColumns must be(List.empty)
+
+      val head3 = response.data(2)
+      head3.primaryKeyName must be(serialSettings.primaryKeyField)
+      serialSettings.referenceField must be(None)
+      serialSettings.hiddenColumns must be(List.empty)
+      serialSettings.nonEditableColumns must be(List.empty)
+
+      val head4 = response.data(3)
+      head4.primaryKeyName must be(serialSettings.primaryKeyField)
+      serialSettings.referenceField must be(None)
+      serialSettings.hiddenColumns must be(List.empty)
+      serialSettings.nonEditableColumns must be(List.empty)
     }
   }
 
@@ -58,9 +93,66 @@ class AdminControllerSpec extends PlayPostgresSpec {
       email must be(emailValue)
     }
 
+    "return data from uuid table" in withApiClient { client =>
+      val name = "wiringbits"
+      //val uuid_id =  UUID.randomUUID().toString
+      val request = AdminCreateTable.Request(
+        Map("name" -> name)
+      )
+      client.createItem(uuidSettings.tableName, request).futureValue
+
+      val response = client.getTableMetadata(uuidSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+      val head = response.headOption.value
+      // TODO: Find a better way to do this
+      val uuidValue = head.find(_._1 == "id").value._2
+      val nameValue = head.find(_._1 == "name").value._2
+      response.size must be(1)
+      name must be(nameValue)
+      isValidUUID(uuidValue) must be(true)
+    }
+
+    "return data from serial table" in withApiClient { client =>
+      val name = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name))
+      client.createItem(serialSettings.tableName, request).futureValue
+
+      val response = client.getTableMetadata(serialSettings.tableName, List("name", "ASC"), List(0,9), "{}").futureValue
+      val head = response.headOption.value
+      // TODO: Find a better way to do this
+      val intValue = head.find(_._1 == "id").value._2
+      val nameValue = head.find(_._1 == "name").value._2
+      response.size must be(1)
+      intValue must be("1")
+      name must be(nameValue)
+    }
+    "return data from big serial table" in withApiClient { client =>
+      val name = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name))
+      client.createItem(bigSerialSettings.tableName, request).futureValue
+
+      val response = client.getTableMetadata(bigSerialSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+      val head = response.headOption.value
+      // TODO: Find a better way to do this
+      val intValue = head.find(_._1 == "id").value._2
+      val nameValue = head.find(_._1 == "name").value._2
+      response.size must be(1)
+      intValue must be("1")
+      name must be(nameValue)
+    }
+
+
     "return a empty map if there isn't any user" in withApiClient { client =>
       val response = client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       response.size must be(0)
+    }
+    
+    "return an empty map if tables are empty" in withApiClient { client =>
+      val response = client.getTableMetadata(uuidSettings.tableName, List("id", "ASC"), List(0,9), "{}").futureValue
+      response.size must be(0)
+      val response2 = client.getTableMetadata(serialSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
+      response2.size must be(0)
+      val response3 = client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
+      response3.size must be(0)
     }
 
     "return a empty map if start and end is the same" in withApiClient { client =>
@@ -71,6 +163,24 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
       val response = client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 0), "{}").futureValue
       response.size must be(0)
+    }
+
+    "return an empty map for range of zero length" in withApiClient { client =>
+      val name = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name)) // can use this for all 3 of the simple tables UUID, SERIAL, BIGSERIAL
+
+      client.createItem(uuidSettings.tableName, request).futureValue // 1
+      val response1 = client.getTableMetadata(uuidSettings.tableName, List("id","ASC"), List(0,0), "{}").futureValue
+      response1.size must be (0)
+
+      client.createItem(serialSettings.tableName, request).futureValue // 2
+      val response2 = client.getTableMetadata(serialSettings.tableName, List("id","ASC"), List(0,0), "{}").futureValue
+      response2.size must be (0)
+
+      client.createItem(bigSerialSettings.tableName, request).futureValue // 2
+      val response3 = client.getTableMetadata(bigSerialSettings.tableName, List("id", "ASC"), List(0, 0), "{}").futureValue
+      response3.size must be(0)
+
     }
 
     "only return the end minus start elements" in withApiClient { client =>
@@ -87,7 +197,32 @@ class AdminControllerSpec extends PlayPostgresSpec {
       response.size must be(returnedElements)
     }
 
+    "only return the range size of elements" in withApiClient { client =>
+      val end = 2
+      val start = 1
+      val returnedElements = end - start
+      //val data = Map() // data for these tables is always nothing. BIG/SERIAL autogenerated.
+      val name = "wiringbits"
+
+      val tables = List(uuidSettings, serialSettings, bigSerialSettings)
+      // this could just be a for loop instead of for comprehension
+      for(table <- tables)
+        yield {
+          Range.apply(0, 4).foreach { _ =>
+            val request = AdminCreateTable.Request(Map("name" -> name)) // tried using data and got error. I thought val data was in scope but perhaps not
+            client.createItem(table.tableName, request).futureValue
+          }
+        }
+
+      for(table <- tables)
+        yield {
+          val response = client.getTableMetadata(table.tableName, List("id", "ASC"), List(start, end), "{}").futureValue
+          response.size must be(returnedElements)
+        }
+    }
+
     "return the elements in ascending order" in withApiClient { client =>
+      // should really be 5, since 5 users are created. Or Range.apply should start at 1.
       val createdUsers = 4
       val nameLength = 7
       Range.apply(0, createdUsers).foreach { i =>
@@ -103,6 +238,35 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val name = head.find(_._1 == "name").value._2
       response.size must be(createdUsers)
       name must be(StringUtils.repeat('A', nameLength))
+    }
+
+    // TODO: add uuidSettings table to tests below
+    "return the elements of all tables in ascending order" in withApiClient { client =>
+      val createdRows = 4
+      val tables = List(serialSettings, bigSerialSettings)
+      val name = "wiringbits"
+      val expectedName = name + "0"
+
+      // insert rows
+      for( table <- tables)
+        yield {
+          Range.apply(0, createdRows).foreach { i =>
+            val request = AdminCreateTable.Request(Map("name" -> s"$name$i"))
+            client.createItem(table.tableName, request).futureValue
+        }
+      }
+
+      for( table <- tables)
+        yield {
+          val response =
+            client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, createdRows), "{}").futureValue
+          val head = response.headOption.value
+          val id = head.find(_._1 == "id").value._2 // id from response
+          val nameValue = head.find(_._1 == "name").value._2 // name from response
+          response.size must be(createdRows)
+          id must be("1")
+          nameValue must be(expectedName)
+        }
     }
 
     "return the elements in descending order" in withApiClient { client =>
@@ -121,6 +285,33 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val name = head.find(_._1 == "name").value._2
       response.size must be(createdUsers)
       name must be(StringUtils.repeat('D', nameLength))
+    }
+    "return the elements of all tables in descending order" in withApiClient { client =>
+      val createdRows = 4
+      // removed uuidSettings because ordering is random
+      val tables = List(serialSettings, bigSerialSettings)
+      val name = "Johnny"
+      val expectedNameValue = name + (createdRows - 1).toString
+      // insert rows
+      for (table <- tables)
+        yield {
+          Range.apply(0, createdRows).foreach { i =>
+            val request = AdminCreateTable.Request(Map("name" -> s"$name$i"))
+            client.createItem(table.tableName, request).futureValue
+          }
+        }
+
+      for (table <- tables)
+        yield {
+          val response =
+            client.getTableMetadata(table.tableName, List("name", "DESC"), List(0, createdRows), "{}").futureValue
+          val head = response.headOption.value
+          val id = head.find(_._1 == "id").value._2 // id from response
+          val nameValue = head.find(_._1 == "name").value._2 // name from response
+          response.size must be(createdRows)
+          id must be(createdRows.toString) // toString
+          expectedNameValue must be(nameValue)
+        }
     }
 
     "return filtered elements" in withApiClient { client =>
@@ -147,12 +338,45 @@ class AdminControllerSpec extends PlayPostgresSpec {
       email must be(expectedEmail)
     }
 
+    "return filtered elements for all tables" in withApiClient { client =>
+      val createdRows = 4
+      val tables = List(serialSettings,bigSerialSettings)
+
+      for( table <- tables) {
+        Range.apply(0, createdRows).foreach { i =>
+          val data = Map("name" -> s"wiringbits$i")
+          val request = AdminCreateTable.Request(data)
+          client.createItem(table.tableName, request).futureValue
+        }
+      }
+      val expectedName = "wiringbits0"
+
+      for( table <- tables) {
+        val response =
+          client
+            .getTableMetadata(
+              table.tableName,
+              List("name", "ASC"),
+              List(0, createdRows),
+              s"""{"name":"$expectedName"}"""
+            )
+            .futureValue
+
+        val head = response.headOption.value
+        val name = head.find(_._1 == "name").value._2
+        response.size must be(1)
+        name must be(expectedName)
+      }
+    }
+
     "fail when table doesn't exists" in withApiClient { client =>
       val invalidTableName = "aaaaaaaaaaa"
       val error = client.getTableMetadata(invalidTableName, List("name", "ASC"), List(0, 9), "{}").expectError
       error must be(s"Unexpected error because the DB table wasn't found: $invalidTableName")
     }
   }
+
+
 
   "GET /admin/tables/:tableName/:primaryKey" should {
     "return table row" in withApiClient { client =>
@@ -172,10 +396,38 @@ class AdminControllerSpec extends PlayPostgresSpec {
       response.find(_._1 == "id").value._2 must be(userId)
     }
 
+    "return table row for all tables" in withApiClient { client =>
+      val tables = List(serialSettings, bigSerialSettings)
+      val name = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name))
+
+      for(table <- tables) {
+        client.createItem(table.tableName, request).futureValue
+
+        val rows = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+        val rowId = rows.headOption.value.find(_._1 == "id").value._2
+
+        val response = client.viewItem(table.tableName, rowId).futureValue
+        response.find(_._1 == "name").value._2 must be(name)
+        response.find(_._1 == "id").value._2 must be(rowId)
+      }
+    }
+
     "fail if the table row doesn't exists" in withApiClient { client =>
       val userId = UUID.randomUUID().toString
       val error = client.viewItem(usersSettings.tableName, userId).expectError
       error must be(s"Cannot find item in users with id $userId")
+    }
+
+    "fail if the table row doesn't exists for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      val rand = new Random()
+      val id = rand.nextInt(1000) + 100
+      for( table <- tables) {
+        val tableName = table.tableName
+        val error = client.viewItem(table.tableName, id.toString).expectError
+        error must be(s"Cannot find item in $tableName with id $id")
+      }
     }
   }
 
@@ -200,10 +452,43 @@ class AdminControllerSpec extends PlayPostgresSpec {
       samePassword must be(true)
     }
 
+    "return table rows for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      val numOfCreatedRows = 3
+      for(table <- tables) {
+        Range.apply(0, numOfCreatedRows).foreach { i =>
+          val request = AdminCreateTable
+            .Request(Map("name" -> s"wiringbits$i"))
+          client.createItem(table.tableName, request).futureValue
+        }
+        val rows = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+        val ids = rows.map(_.find(_._1 == "id").value._2)
+        val response = client.viewItems(table.tableName, ids).futureValue
+        // TODO: check the names
+        // val sameName = response.flatMap(_.find(_._1 == "name")).forall(_._2 == "wiringbits")
+
+        response.size must be(ids.length)
+        response.size must be(numOfCreatedRows)
+        /*sameName must be(true)
+        samePassword must be(true)*/
+      }
+    }
+
     "fail if the table row doesn't exists" in withApiClient { client =>
       val userIds = List(UUID.randomUUID().toString)
       val error = client.viewItems("users", userIds).expectError
       error must be(s"Cannot find item in users with id ${userIds.headOption.value}")
+    }
+
+    "fail if the table row doesn't exists for all tables" in withApiClient { client =>
+      val tables = List(serialSettings, bigSerialSettings)
+      val rand = new Random()
+      val ids = List((rand.nextInt(1000) + 100).toString)
+      for(table <- tables) {
+        val tableName = table.tableName
+        val error = client.viewItems(tableName, ids).expectError
+        error must be(s"Cannot find item in $tableName with id ${ids.headOption.value}")
+      }
     }
   }
 
@@ -217,12 +502,33 @@ class AdminControllerSpec extends PlayPostgresSpec {
       response.noData must be(empty)
     }
 
+    "create a new row for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      val name = "wiringbits"
+
+      for(table <- tables) {
+        val request = AdminCreateTable.Request(Map("name" -> name))
+        val response = client.createItem(table.tableName, request).futureValue
+        response.noData must be(empty)
+      }
+    }
+
     "fail when a mandatory field is not sent" in withApiClient { client =>
       val name = "wiringbits"
       val request = AdminCreateTable.Request(Map("name" -> name))
 
       val error = client.createItem("users", request).expectError
       error must be(s"There are missing fields: email, password")
+    }
+
+    "fail when a mandatory field is not sent for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      //val name = "wiringbits"
+      for(table <- tables) {
+        val request = AdminCreateTable.Request(Map())
+        val error = client.createItem(table.tableName, request).expectError
+        error must be(s"There are missing fields: name")
+      }
     }
   }
 
@@ -233,6 +539,17 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
     val error = client.createItem("users", request).expectError
     error must be(s"A field doesn't correspond to this table schema")
+  }
+  "fail when field in request doesn't exists for all tables" in withApiClient { client =>
+    val tables = List(serialSettings,bigSerialSettings)
+    val name = "wiringbits"
+    val nonExistentField = "nonExistentField"
+    for(table <- tables) {
+      val request = AdminCreateTable.Request(Map("name" -> name, "nonExistentField" -> nonExistentField))
+
+      val error = client.createItem(table.tableName, request).expectError
+      error must be(s"A field doesn't correspond to this table schema")
+    }
   }
 
   "PUT /admin/tables/:tableName" should {
@@ -255,6 +572,27 @@ class AdminControllerSpec extends PlayPostgresSpec {
       emailResponse must be(email)
     }
 
+    "update a new row for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      for(table <- tables) {
+        val request = AdminCreateTable.Request(
+          Map("name" -> "wiringbits")
+        )
+        client.createItem(table.tableName, request).futureValue
+        val response = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+        val id = response.headOption.value.find(_._1 == "id").value._2
+
+        val name = "wiringbitsbitsbits"
+        val updateRequest = Map("name" -> name)
+        val updateResponse = client.updateItem(table.tableName, id, updateRequest).futureValue
+
+        val newResponse = client.viewItem(table.tableName, id).futureValue
+        val nameResponse = newResponse.find(_._1 == "name").value._2
+        updateResponse.id must be(id)
+        nameResponse must be(name)
+      }
+    }
+
     "fail if the field in body doesn't exists" in withApiClient { client =>
       val request = AdminCreateTable.Request(
         Map("name" -> "wiringbits", "email" -> "test@wiringbits.net", "password" -> "wiringbits")
@@ -268,6 +606,24 @@ class AdminControllerSpec extends PlayPostgresSpec {
       val updateRequest = Map("nonExistentField" -> email)
       val error = client.updateItem("users", userId, updateRequest).expectError
       error must be("A field doesn't correspond to this table schema")
+    }
+
+    "fail if the field in body doesn't exists for all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      for(table <- tables) {
+        val request = AdminCreateTable.Request(
+          Map("name" -> "test")
+        )
+        client.createItem(table.tableName, request).futureValue
+
+        val response = client.getTableMetadata(table.tableName, List("id", "ASC"), List(0, 9), "{}").futureValue
+        val id = response.headOption.value.find(_._1 == "id").value._2
+
+        val name = "wiringbits"
+        val updateRequest = Map("nonExistentField" -> name)
+        val error = client.updateItem(table.tableName, id, updateRequest).expectError
+        error must be("A field doesn't correspond to this table schema")
+      }
     }
   }
 
@@ -286,6 +642,26 @@ class AdminControllerSpec extends PlayPostgresSpec {
 
       val newResponse = client.getTableMetadata("users", List("name", "ASC"), List(0, 9), "{}").futureValue
       newResponse.isEmpty must be(true)
+    }
+  }
+
+  "DELETE /admin/tables/:tableName" should {
+    "delete a new row in all tables" in withApiClient { client =>
+      val tables = List(serialSettings,bigSerialSettings)
+      val name = "wiringbits"
+      val request = AdminCreateTable.Request(Map("name" -> name))
+
+      for(table <- tables) {
+        client.createItem(table.tableName, request).futureValue
+
+        val response = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+        val id = response.headOption.value.find(_._1 == "id").value._2
+
+        client.deleteItem(table.tableName, id).futureValue
+
+        val newResponse = client.getTableMetadata(table.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
+        newResponse.isEmpty must be(true)
+      }
     }
   }
 }

--- a/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
+++ b/admin-data-explorer-play-server/src/test/scala/controllers/AdminControllerSpec.scala
@@ -143,7 +143,7 @@ class AdminControllerSpec extends PlayPostgresSpec {
       intValue must be("1")
       name must be(nameValue)
     }
-    
+
     "return a empty map if there isn't any user" in withApiClient { client =>
       val response = client.getTableMetadata(usersSettings.tableName, List("name", "ASC"), List(0, 9), "{}").futureValue
       response.size must be(0)

--- a/admin-data-explorer-play-server/src/test/scala/net/wiringbits/webapp/utils/admin/modules/DataExplorerTestModule.scala
+++ b/admin-data-explorer-play-server/src/test/scala/net/wiringbits/webapp/utils/admin/modules/DataExplorerTestModule.scala
@@ -11,6 +11,9 @@ class DataExplorerTestModule extends AbstractModule {
   }
 
   val settings: List[TableSettings] = List(
-    TableSettings("users", "user_id")
+    TableSettings("users", "user_id"), // "UUID" default
+    TableSettings(tableName = "uuid_table", primaryKeyField = "id", primaryKeyDataType = "UUID"), // explicit default
+    TableSettings(tableName = "serial_table", primaryKeyField = "id", primaryKeyDataType = "Int"),
+    TableSettings(tableName = "big_serial_table", primaryKeyField = "id", primaryKeyDataType = "Int"),
   )
 }

--- a/admin-data-explorer-play-server/src/test/scala/net/wiringbits/webapp/utils/admin/modules/DataExplorerTestModule.scala
+++ b/admin-data-explorer-play-server/src/test/scala/net/wiringbits/webapp/utils/admin/modules/DataExplorerTestModule.scala
@@ -1,7 +1,7 @@
 package net.wiringbits.webapp.utils.admin.modules
 
 import com.google.inject.{AbstractModule, Provides}
-import net.wiringbits.webapp.utils.admin.config.{DataExplorerSettings, TableSettings}
+import net.wiringbits.webapp.utils.admin.config.{DataExplorerSettings, TableSettings, PrimaryKeyDataType}
 
 class DataExplorerTestModule extends AbstractModule {
 
@@ -12,8 +12,26 @@ class DataExplorerTestModule extends AbstractModule {
 
   val settings: List[TableSettings] = List(
     TableSettings("users", "user_id"), // "UUID" default
-    TableSettings(tableName = "uuid_table", primaryKeyField = "id", primaryKeyDataType = "UUID"), // explicit default
-    TableSettings(tableName = "serial_table", primaryKeyField = "id", primaryKeyDataType = "Int"),
-    TableSettings(tableName = "big_serial_table", primaryKeyField = "id", primaryKeyDataType = "Int"),
+    TableSettings(
+      tableName = "uuid_table",
+      primaryKeyField = "id",
+      primaryKeyDataType = PrimaryKeyDataType.UUID
+    ), // explicit default
+    TableSettings(tableName = "serial_table", primaryKeyField = "id", primaryKeyDataType = PrimaryKeyDataType.Serial),
+    TableSettings(
+      tableName = "big_serial_table",
+      primaryKeyField = "id",
+      primaryKeyDataType = PrimaryKeyDataType.BigSerial
+    ),
+    TableSettings(
+      tableName = "serial_table_overflow",
+      primaryKeyField = "id",
+      primaryKeyDataType = PrimaryKeyDataType.Serial
+    ),
+    TableSettings(
+      tableName = "big_serial_table_overflow",
+      primaryKeyField = "id",
+      primaryKeyDataType = PrimaryKeyDataType.BigSerial
+    )
   )
 }


### PR DESCRIPTION
DatabaseTablesRepository

Add primaryKeyType to update and delete methods.

DatabaseTablesDAO

Add primaryKeyType default "UUID" to signatures for find, create, update methods Add special handling for "UUID" vs other types in create method. Pass SERIAL values as Int by using preparedStatement.setInt instead of toObject

Play Evolutions

Make new test table definitions 'id', 'name' column to make SERIAL default value insertion easier.