### PR TITLE
Add stOutputPackage to scalablytyped project 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val webappCommon = (crossProject(JSPlatform, JVMPlatform) in file("webapp-c
   */
 lazy val slinkyUtils = (project in file("slinky-utils"))
   .configure(baseLibSettings, baseWebSettings)
-  .configure(_.enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin, ScalablyTypedConverterPlugin))
+  .configure(_.enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin, ScalablyTypedConverterGenSourcePlugin))
   .dependsOn(webappCommon.js)
   .settings(
     name := "slinky-utils",
@@ -100,6 +100,7 @@ lazy val slinkyUtils = (project in file("slinky-utils"))
     useYarn := true,
     stFlavour := Flavour.Slinky,
     Compile / stMinimize := Selection.All,
+    stOutputPackage := "net.wiringbits.webapp.utils.slinkyUtils",
     stIgnore ++= List(
       "react-proxy",
       "@mui/material",
@@ -125,7 +126,7 @@ lazy val slinkyUtils = (project in file("slinky-utils"))
     ),
     Compile / npmDevDependencies ++= Seq(
       "@types/react" -> "18.0.33",
-      "@types/react-dom" -> "18.0.11",
+      "@types/react-dom" -> "18.0.11"
     )
   )
 


### PR DESCRIPTION
This should fix template errors, like:

```
[error] sbt.librarymanagement.ResolveException: Error downloading org.scalablytyped:prop-types_sjs1_3:15.7.4-ed2bcf
[error]   Not found
[error]   Not found
[error]   not found: /home/runner/.ivy2/localorg.scalablytyped/prop-types_sjs1_3/15.7.4-ed2bcf/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/org/scalablytyped/prop-types_sjs1_3/15.7.4-ed2bcf/prop-types_sjs1_3-15.7.4-ed2bcf.pom
```