### PR TITLE
Remove scalablytyped to slinkyUtils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,31 +91,15 @@ lazy val webappCommon = (crossProject(JSPlatform, JVMPlatform) in file("webapp-c
   */
 lazy val slinkyUtils = (project in file("slinky-utils"))
   .configure(baseLibSettings, baseWebSettings)
-  .configure(_.enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin, ScalablyTypedConverterGenSourcePlugin))
+  .configure(_.enablePlugins(ScalaJSPlugin, ScalaJSBundlerPlugin))
   .dependsOn(webappCommon.js)
   .settings(
     name := "slinky-utils",
     Test / fork := false, // sjs needs this to run tests
-    stTypescriptVersion := "3.9.3",
     useYarn := true,
-    stFlavour := Flavour.Slinky,
-    Compile / stMinimize := Selection.All,
-    stOutputPackage := "net.wiringbits.webapp.utils.slinkyUtils",
-    stIgnore ++= List(
-      "react-proxy",
-      "@mui/material",
-      "@mui/icons-material",
-      "@mui/joy",
-      "@emotion/react",
-      "@emotion/styled",
-      "react-router",
-      "react-router-dom"
-    ),
     Compile / npmDependencies ++= Seq(
       "react" -> "18.2.0",
       "react-dom" -> "18.2.0",
-      "csstype" -> "2.6.11",
-      "react-proxy" -> "1.1.8",
       "@mui/material" -> "5.11.16",
       "@mui/icons-material" -> "5.11.16",
       "@mui/joy" -> "5.0.0-alpha.74",
@@ -123,10 +107,6 @@ lazy val slinkyUtils = (project in file("slinky-utils"))
       "@emotion/styled" -> "11.10.6",
       "react-router" -> "5.1.2",
       "react-router-dom" -> "5.1.2"
-    ),
-    Compile / npmDevDependencies ++= Seq(
-      "@types/react" -> "18.0.33",
-      "@types/react-dom" -> "18.0.11"
     )
   )
 


### PR DESCRIPTION
Currently, we don't need to convert TS to Scala.js using Scalablytyped
Removed unused npmDeps